### PR TITLE
Add destination directory as an option

### DIFF
--- a/discogstagger/taggerutils.py
+++ b/discogstagger/taggerutils.py
@@ -40,7 +40,7 @@ class TaggerUtils(object):
     # supported file types.
     FILE_TYPE = (".mp3", ".flac",)
 
-    def __init__(self, sourcedir, ogsrelid):
+    def __init__(self, sourcedir, destdir, ogsrelid):
         self.group_name = "jW"
         self.dir_format = "%ALBARTIST%-%ALBTITLE%-(%CATNO%)-%YEAR%-%GROUP%"
         self.m3u_format = "00-%ALBARTIST%-%ALBTITLE%.m3u"
@@ -48,6 +48,7 @@ class TaggerUtils(object):
         self.song_format = "%TRACKNO%-%ARTIST%-%TITLE%%TYPE%"
 
         self.sourcedir = sourcedir
+        self.destdir = destdir
         self.files_to_tag = self._get_target_list()
         self.album = DiscogsAlbum(ogsrelid)
 
@@ -122,7 +123,7 @@ class TaggerUtils(object):
     def dest_dir_name(self):
         """ generates new album directory name """
 
-        path_name = os.path.dirname(self.sourcedir)
+        path_name = os.path.dirname(self.destdir)
         dest_dir = get_clean_filename(self._value_from_tag(self.dir_format))
 
         return os.path.join(path_name, dest_dir)

--- a/scripts/discogs_tagger.py
+++ b/scripts/discogs_tagger.py
@@ -22,6 +22,8 @@ p.add_option("-r", "--releaseid", action="store", dest="releaseid",
              help="The discogs.com release id of the target album")
 p.add_option("-s", "--source", action="store", dest="sdir",
              help="The directory that you wish to tag")
+p.add_option("-d", "--destination", action="store", dest="destdir",
+             help="The (base) directory to copy the tagged files to")
 p.add_option("-c", "--conf", action="store", dest="conffile",
              help="The discogstagger configuration file.")
 
@@ -34,6 +36,11 @@ if not options.releaseid:
 if not options.sdir or not os.path.exists(options.sdir):
     p.error("Please specify a valid source directory ('-s')")
 
+if not options.destdir or not os.path.exists(options.destdir):
+    destdir = options.sdir
+else:
+    destdir = options.destdir
+
 config = ConfigParser.ConfigParser()
 config.read(options.conffile)
 
@@ -42,7 +49,7 @@ logging.basicConfig(level=config.getint("logging", "level"))
 keep_original = config.getboolean("details", "keep_original")
 embed_coverart = config.getboolean("details", "embed_coverart")
 
-release = TaggerUtils(options.sdir, options.releaseid)
+release = TaggerUtils(options.sdir, destdir, options.releaseid)
 release.nfo_format = config.get("file-formatting", "nfo")
 release.m3u_format = config.get("file-formatting", "m3u")
 release.dir_format = config.get("file-formatting", "dir")


### PR DESCRIPTION
Adds a new option (-d) to use a totally separate destination directory.

Unfortunately the current handling of directories is a little strange, in that you have to add a "/" at the end of the directory to use this instead of the parent directory. It works anyway ;-)
